### PR TITLE
chore: Update checkout and node versions to v4

### DIFF
--- a/.github/workflows/deny_dirty_cargo_locks.yml
+++ b/.github/workflows/deny_dirty_cargo_locks.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/dependency_modification_check.yml
+++ b/.github/workflows/dependency_modification_check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
Update checkout and node versions to v4: https://hostingers.atlassian.net/browse/AUTO-3944